### PR TITLE
fix: SK-19 minor improvements - fix 5 

### DIFF
--- a/lib/utils/cookies.ts
+++ b/lib/utils/cookies.ts
@@ -7,7 +7,7 @@ export const setCartIdInCookies = (cartId: string) => {
   cookies().set('vs_shop_cart_id', cartId, {
     maxAge: 60 * 60 * 24 * 7,
     httpOnly: true,
-    sameSite: 'strict',
+    sameSite: 'lax',
     secure: process.env.NODE_ENV === 'production',
   });
 };


### PR DESCRIPTION
This PR introduces following changes into the codebase:

- Fixed an issue where `vs_shop_cart_id` cookie was not sent by iOS browsers (Safari/Chrome) on initial load or tab restore
- Changed cookie configuration in `setCartIdInCookies()`:
  - `sameSite` was updated from `'strict'` to `'lax'`
  - This allows the cookie to be sent during typical user interactions such as reloads, direct URL visits, and mobile tab restores
- Improves cart consistency across platforms and devices