### PR TITLE
Sk 24 concurrent order utility for distributed systems

### DIFF
--- a/data/repository/OrderRepository.test.ts
+++ b/data/repository/OrderRepository.test.ts
@@ -1,67 +1,94 @@
-import { pool, executeQuery } from '@/lib/db';
+import { runInSerializable, executeQuery } from '@/lib/db';
 import {
   createOrderWithItems,
   updateOrderState,
+  getOrderById,
+  cancelOrderWithItems,
 } from '@/data/repository/OrderRepository';
 import { OrderMappers } from '@/data/mappers/orderMappers';
 import { mockOrder } from '@/__test__/mocks';
 
 jest.mock('@/lib/db', () => ({
-  pool: { connect: jest.fn() },
   executeQuery: jest.fn(),
+  runInSerializable: jest.fn(),
 }));
+
 jest.mock('@/data/mappers/orderMappers', () => ({
   OrderMappers: { mapOrder: jest.fn() },
 }));
 
+const mockClient = {
+  query: jest.fn(),
+  release: jest.fn(),
+};
+
+beforeEach(() => {
+  jest.resetAllMocks();
+});
+
 describe('createOrderWithItems', () => {
-  const client = { query: jest.fn(), release: jest.fn() };
-
-  beforeEach(() => {
-    jest.resetAllMocks();
-
-    (pool.connect as jest.Mock).mockResolvedValue(client);
-
-    client.query
-      .mockResolvedValueOnce({}) // BEGIN
-      .mockResolvedValueOnce({ rowCount: 1 }) // updateStock
-      .mockResolvedValueOnce({ rows: [{ order_id: mockOrder.id }] }) // insert order
-      .mockResolvedValueOnce({ rowCount: 1 }) // insert items
-      .mockResolvedValueOnce({ rows: [{}] }) // fetch order
-      .mockResolvedValueOnce({}); // COMMIT
-
+  it('calls mapOrder with fetched rows and returns the order', async () => {
     (OrderMappers.mapOrder as jest.Mock).mockReturnValue(mockOrder);
-  });
+    (runInSerializable as jest.Mock).mockImplementation(async ({ action }) => {
+      mockClient.query
+        .mockResolvedValueOnce({ rowCount: 1 }) // updateStock
+        .mockResolvedValueOnce({ rows: [{ order_id: mockOrder.id }] }) // createOrder
+        .mockResolvedValueOnce({ rowCount: 1 }) // insertOrderItems
+        .mockResolvedValueOnce({ rows: [mockOrder] }); // getOrderById
 
-  it('returns the mapped order and releases the client', async () => {
-    const out = await createOrderWithItems({
+      return action(mockClient);
+    });
+
+    const result = await createOrderWithItems({
       cartId: mockOrder.cartId!,
       shippingAddressId: mockOrder.shippingAddressId,
     });
 
-    expect(out).toBe(mockOrder);
-    expect(client.query).toHaveBeenCalledWith('COMMIT');
-    expect(client.release).toHaveBeenCalled();
+    expect(OrderMappers.mapOrder).toHaveBeenCalledWith([mockOrder]);
+    expect(result).toEqual(mockOrder);
   });
 });
 
-const mockExec = executeQuery as jest.Mock;
-const rows = (rowCount: number): unknown => ({ rowCount, rows: [] }) as unknown;
+describe('getOrderById', () => {
+  it('returns mapped order if found', async () => {
+    (executeQuery as jest.Mock).mockResolvedValue({ rows: [mockOrder] });
+    (OrderMappers.mapOrder as jest.Mock).mockReturnValue(mockOrder);
 
-describe('updateOrderState', () => {
-  beforeEach(() => jest.resetAllMocks());
-
-  it('resolves true when a row is updated', async () => {
-    mockExec.mockResolvedValue(rows(1));
-    await expect(
-      updateOrderState({ orderId: 'o1', state: 'paid' }),
-    ).resolves.toBe(true);
+    const result = await getOrderById('o1');
+    expect(result).toEqual(mockOrder);
   });
 
-  it('resolves false when no row matches', async () => {
-    mockExec.mockResolvedValue(rows(0));
-    await expect(
-      updateOrderState({ orderId: 'missing', state: 'paid' }),
-    ).resolves.toBe(false);
+  it('returns null if not found', async () => {
+    (executeQuery as jest.Mock).mockResolvedValue({ rows: [] });
+    const result = await getOrderById('o2');
+    expect(result).toBeNull();
+  });
+});
+
+describe('updateOrderState', () => {
+  it('returns true when rowCount is > 0', async () => {
+    (executeQuery as jest.Mock).mockResolvedValue({ rowCount: 1 });
+    const result = await updateOrderState({ orderId: 'o1', state: 'paid' });
+    expect(result).toBe(true);
+  });
+
+  it('returns false when rowCount is 0', async () => {
+    (executeQuery as jest.Mock).mockResolvedValue({ rowCount: 0 });
+    const result = await updateOrderState({ orderId: 'o1', state: 'paid' });
+    expect(result).toBe(false);
+  });
+});
+
+describe('cancelOrderWithItems', () => {
+  it('returns true when both updates succeed', async () => {
+    (runInSerializable as jest.Mock).mockImplementation(async ({ action }) => {
+      mockClient.query
+        .mockResolvedValueOnce({ rowCount: 1 }) // updateOrderState
+        .mockResolvedValueOnce({ rowCount: 1 }); // restoreStock
+      return action(mockClient);
+    });
+
+    const result = await cancelOrderWithItems('o1');
+    expect(result).toBe(true);
   });
 });

--- a/lib/const.ts
+++ b/lib/const.ts
@@ -11,6 +11,8 @@ export type ConfigConst = {
   orderStates: readonly string[];
   supportEmail: string;
   missingImage: string;
+  maxSerializableRetries: number;
+  serializableBaseDelayMs: number;
 };
 
 export const CONST: ConfigConst = {
@@ -22,4 +24,6 @@ export const CONST: ConfigConst = {
   orderStates: ['created', 'paid', 'shipped', 'cancelled', 'refunded'] as const,
   supportEmail: process.env.NEXT_PUBLIC_SUPPORT_EMAIL || 'support@vsskate.com',
   missingImage: '/assets/missing_image.webp',
+  maxSerializableRetries: 3,
+  serializableBaseDelayMs: 50,
 };

--- a/lib/types/Error.ts
+++ b/lib/types/Error.ts
@@ -1,0 +1,4 @@
+export type GenericError = {
+  code?: string;
+  message?: string;
+};

--- a/lib/types/index.ts
+++ b/lib/types/index.ts
@@ -14,3 +14,4 @@ export * from './CodedField';
 export * from './Country';
 export * from './Payment';
 export * from './User';
+export * from './Error';

--- a/lib/utils/utils.ts
+++ b/lib/utils/utils.ts
@@ -134,3 +134,8 @@ export function isProtectedPath(rawPath: string): boolean {
 
   return CONST.protectedPages.includes(page);
 }
+
+export const sleep = (ms: number): Promise<void> =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms);
+  });

--- a/use-cases/address.ts
+++ b/use-cases/address.ts
@@ -11,9 +11,9 @@ export async function upsertShippingAddressUseCase(
 ): Promise<Address> {
   try {
     return await upsertShippingAddress(shippingAddress);
-  } catch (err) {
+  } catch (error) {
     log.error(
-      { shippingAddress, error: printException(err) },
+      { shippingAddress, error: printException(error) },
       'Error occurred while finding or creating shipping address',
     );
 

--- a/use-cases/order.ts
+++ b/use-cases/order.ts
@@ -18,14 +18,14 @@ export async function createOrderUseCase({
 }): Promise<Order> {
   try {
     return await createOrderWithItems({ cartId, shippingAddressId });
-  } catch (err) {
+  } catch (error) {
     log.error(
-      { cartId, shippingAddressId, err: printException(err) },
+      { cartId, shippingAddressId, error: printException(error) },
       'Error occurred during order creation',
     );
 
-    if (err instanceof PublicError) {
-      throw err;
+    if (error instanceof PublicError) {
+      throw error;
     }
 
     throw new PublicError({
@@ -39,14 +39,14 @@ export async function createOrderUseCase({
 export async function cancelOrderUseCase(orderId: string): Promise<boolean> {
   try {
     return await cancelOrderWithItems(orderId);
-  } catch (err) {
+  } catch (error) {
     log.error(
-      { orderId, error: printException(err) },
+      { orderId, error: printException(error) },
       'Error while cancelling order',
     );
 
-    if (err instanceof PublicError) {
-      throw err;
+    if (error instanceof PublicError) {
+      throw error;
     }
 
     throw new PublicError({


### PR DESCRIPTION
This PR introduces the following changes into the codebase:

- Adds a `runInSerializable` utility function to handle concurrent order creation and cancellation using PostgreSQL SERIALIZABLE transactions.
- Refactors the `createOrder` and `cancelOrder` use cases to run within this utility, ensuring safe execution in distributed environments (e.g. behind an Application Load Balancer).
- Adds tests for the retry logic in `runInSerializable`, specifically handling SQLSTATE 40001 serialization conflicts.
- Renames variables such as `err` to `error` to maintain naming consistency.